### PR TITLE
use jest-compact-reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
       },
       "devDependencies": {
         "prettier": "^2.7.1",
+        "jest-compact-reporter": "^1.2.9",
         "qs": "^6.11.0"
       },
       "engines": {
@@ -4957,6 +4958,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "node_modules/assert-never": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
+      "dev": true
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
@@ -9975,6 +9982,15 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-compact-reporter": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/jest-compact-reporter/-/jest-compact-reporter-1.2.9.tgz",
+      "integrity": "sha512-s8SsyiFQu9aniDyZ/t7FAEVxjMzUryHM7e1Leef4DZwyDCNJyGUclREJyvi4cN9yCtu7PSXx3ms47OqpFzUA4w==",
+      "dev": true,
+      "dependencies": {
+        "assert-never": "^1.2.1"
       }
     },
     "node_modules/jest-config": {
@@ -19828,6 +19844,12 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "assert-never": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
+      "dev": true
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -23571,6 +23593,15 @@
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
+      }
+    },
+    "jest-compact-reporter": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/jest-compact-reporter/-/jest-compact-reporter-1.2.9.tgz",
+      "integrity": "sha512-s8SsyiFQu9aniDyZ/t7FAEVxjMzUryHM7e1Leef4DZwyDCNJyGUclREJyvi4cN9yCtu7PSXx3ms47OqpFzUA4w==",
+      "dev": true,
+      "requires": {
+        "assert-never": "^1.2.1"
       }
     },
     "jest-config": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "start": "concurrently -n frontend,backend -c red,green 'HOST=${HOST:=127.0.0.1} PORT=${PORT:=3001} react-scripts start' 'npm:serve'",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --reporters default --reporters jest-compact-reporter",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "prettier": "^2.7.1",
+    "jest-compact-reporter": "^1.2.9",
     "qs": "^6.11.0"
   }
 }


### PR DESCRIPTION
Using jest-compact-reporter can make it easier to see your failing tests.

This PR will maintain the default reporter that comes with CRA, and add jest-compact-reporter, the output of which will be concatenated to the end of the test output.