### PR TITLE
move tubmap function calls into TubeMapContainer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,6 @@ import { urlParamsToViewTarget } from "./components/CopyLink";
 import CustomizationAccordion from "./components/CustomizationAccordion";
 import Footer from "./components/Footer";
 import { dataOriginTypes } from "./enums";
-import * as tubeMap from "./util/tubemap";
 import config from "./config.json";
 
 class App extends Component {
@@ -47,27 +46,6 @@ class App extends Component {
     };
   }
 
-  componentDidUpdate() {
-    const { visOptions } = this.state;
-    visOptions.compressedView
-      ? tubeMap.setNodeWidthOption(1)
-      : tubeMap.setNodeWidthOption(0);
-    tubeMap.setMergeNodesFlag(visOptions.removeRedundantNodes);
-    tubeMap.setTransparentNodesFlag(visOptions.transparentNodes);
-    tubeMap.setShowReadsFlag(visOptions.showReads);
-    tubeMap.setSoftClipsFlag(visOptions.showSoftClips);
-
-    // apply new colorReadsByMappingQuality value to all tracks
-    // to be changed, add options to change colorReadsByMappingQuality individually
-    tubeMap.setColorReadsByMappingQualityFlag(visOptions.colorReadsByMappingQuality);
-
-    for (let i = 0; i < visOptions.colorSchemes.length; i++) {
-      // update tubemap colors 
-      tubeMap.setColorSet(i, visOptions.colorSchemes[i]);
-    }
-    tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
-
-  }
   /*
    * Drop undefined values
    * See https://stackoverflow.com/questions/286141/remove-blank-attributes-from-an-object-in-javascript/38340730#38340730
@@ -163,6 +141,7 @@ class App extends Component {
           viewTarget={this.state.viewTarget}
           dataOrigin={this.state.dataOrigin}
           apiUrl={this.props.apiUrl}
+          visOptions={this.state.visOptions}
         />
         <CustomizationAccordion
           visOptions={this.state.visOptions}

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -54,6 +54,31 @@ class TubeMapContainer extends Component {
         this.getRemoteTubeMapData();
       }
     }
+    // updating visOptions will cause an error if the tubemap is not in place yet.
+    if(!this.state.isLoading) {
+      this.updateVisOptions();
+    }
+  }
+
+  updateVisOptions() {
+    const visOptions = this.props.visOptions;
+    visOptions.compressedView
+      ? tubeMap.setNodeWidthOption(1)
+      : tubeMap.setNodeWidthOption(0);
+    tubeMap.setMergeNodesFlag(visOptions.removeRedundantNodes);
+    tubeMap.setTransparentNodesFlag(visOptions.transparentNodes);
+    tubeMap.setShowReadsFlag(visOptions.showReads);
+    tubeMap.setSoftClipsFlag(visOptions.showSoftClips);
+
+    // apply new colorReadsByMappingQuality value to all tracks
+    // to be changed, add options to change colorReadsByMappingQuality individually
+    tubeMap.setColorReadsByMappingQualityFlag(visOptions.colorReadsByMappingQuality);
+
+    for (let i = 0; i < visOptions.colorSchemes.length; i++) {
+      // update tubemap colors
+      tubeMap.setColorSet(i, visOptions.colorSchemes[i]);
+    }
+    tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
   }
 
   render() {
@@ -238,6 +263,7 @@ TubeMapContainer.propTypes = {
   apiUrl: PropTypes.string.isRequired,
   dataOrigin: PropTypes.oneOf(Object.values(dataOriginTypes)).isRequired,
   viewTarget: PropTypes.object.isRequired,
+  visOptions: PropTypes.object.isRequired,
 };
 
 export default TubeMapContainer;


### PR DESCRIPTION
Having `tubemap` functions in `App.js` makes it easy to introduce errors when calling imperative functions on the tubemap module. It's better to have all those confined to `TubeMapContainer`.

This PR removes all tubemap functions from `App.js` and puts them into `TubeMapContainer.js`. Instead of being called when App updates, they will be called when TubeMapContainer updates. This allows us to check `isLoading` in order to prevent calling tubemap functions before the track has loaded.