### PR TITLE
Read info tooltip that supports copy-paste

### DIFF
--- a/src/components/TrackInfoPopper.js
+++ b/src/components/TrackInfoPopper.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Popper from '@mui/material/Popper';
+import ClickAwayListener from '@mui/base/ClickAwayListener';
+
+export default function TrackInfoPopper({content, anchorEl, handleClose}) {
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'track-info-popper' : undefined;
+
+  return (
+    <div>
+      <Popper id={id} open={open} anchorEl={anchorEl}>
+        <ClickAwayListener onClickAway={handleClose}>
+          <Box sx={{ border: 1, p: 1, bgcolor: 'background.paper' }}>
+            {content}
+          </Box>
+        </ClickAwayListener>
+      </Popper>
+    </div>
+  );
+}

--- a/src/components/TubeMap.js
+++ b/src/components/TubeMap.js
@@ -5,10 +5,26 @@ import * as tubeMap from "../util/tubemap";
 class TubeMap extends Component {
   componentDidMount() {
     this.createTubeMap();
+    if(this.props.onTrackClick) {
+      tubeMap.setEventHandler("trackClick", this.props.onTrackClick);
+    } else {
+      tubeMap.setEventHandler("trackClick", null); 
+    }
   }
 
-  componentDidUpdate() {
-    this.createTubeMap();
+  componentDidUpdate(prevProps) {
+    if(prevProps.nodes !== this.props.nodes   ||
+       prevProps.tracks !== this.props.tracks ||
+       prevProps.reads !== this.props.reads   ||
+       prevProps.region !== this.props.region
+      ){
+      this.createTubeMap();
+    }
+    if(this.props.onTrackClick) {
+      tubeMap.setEventHandler("trackClick", this.props.onTrackClick);
+    } else {
+      tubeMap.setEventHandler("trackClick", null); 
+    }
   }
 
   createTubeMap = () => {
@@ -31,6 +47,7 @@ TubeMap.propTypes = {
   tracks: PropTypes.array.isRequired,
   reads: PropTypes.array.isRequired,
   region: PropTypes.array.isRequired,
+  onTrackClick: PropTypes.func
 };
 
 export default TubeMap;

--- a/src/components/TubeMap.js
+++ b/src/components/TubeMap.js
@@ -13,6 +13,8 @@ class TubeMap extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    // Avoid unnecessary updates.
+    // Particularly updates if only the callback fn is re-initialized.
     if(prevProps.nodes !== this.props.nodes   ||
        prevProps.tracks !== this.props.tracks ||
        prevProps.reads !== this.props.reads   ||

--- a/src/components/TubeMap.test.js
+++ b/src/components/TubeMap.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, fireEvent }  from '@testing-library/react';
+
+import TubeMap from './TubeMap';
+import * as tubeMap from '../util/tubemap';
+import * as exampleData from '../util/demo-data';
+
+let data;
+let onTrackClick;
+
+// Prepare mock data from Example 6.
+const readsFromStringToArray = (readsString) => {
+    const lines = readsString.split("\n");
+    const result = [];
+    lines.forEach((line) => {
+      if (line.length > 0) {
+        result.push(JSON.parse(line));
+      }
+    });
+    return result;
+};
+
+let vg6 = JSON.parse(exampleData.k3138);
+let ex6nodes = tubeMap.vgExtractNodes(vg6)
+let ex6tracks = tubeMap.vgExtractTracks(vg6)
+let ex6 = {
+  nodes: ex6nodes,
+  tracks: ex6tracks,
+  reads:tubeMap.vgExtractReads(
+    ex6nodes,
+    ex6tracks,
+    readsFromStringToArray(exampleData.demoReads)
+  ) 
+}
+
+describe('TubeMap test', () => {
+    beforeEach(()=>{
+        data = ex6;
+        onTrackClick = jest.fn();
+
+        render(
+          // tubemap.js requires the tube map to be wrapped 
+          // in a div with id tubeMapSVG
+          // and to have a div with legendDiv in the document.
+          <div>
+              <div id="legendDiv">
+              </div>
+              <div id="tubeMapContainer">
+                <div id="tubeMapSVG">
+                  <TubeMap
+                    nodes={data.nodes}
+                    tracks={data.tracks}
+                    reads={data.reads}
+                    region={data.region}
+                    onTrackClick={onTrackClick}
+                  />
+                </div>
+              </div>
+          </div>);
+    });
+
+    it('It loads a tube map', async () => {
+        // All the tracks are loaded and rendered in the SVG.
+        expect(document.querySelector("[trackID='0']")).not.toBeNull();
+        expect(document.querySelector("[trackID='1']")).not.toBeNull();
+        expect(document.querySelector("[trackID='2']")).not.toBeNull();
+        expect(document.querySelector("[trackID='3']")).not.toBeNull();
+        expect(document.querySelector("[trackID='4']")).not.toBeNull();
+    });
+
+    it('It calls callback on track click', async () => {
+      // Click Track 0
+      let track0 = document.querySelector("[trackID='0']");
+      await fireEvent.click(track0);
+
+      // Expect callback to be called with
+      // Title, TrackID, target element
+      expect(onTrackClick).toBeCalledTimes(1);
+      expect(onTrackClick).toBeCalledWith("gi|157734152:29694183-29697368", "0", track0);
+    });
+});

--- a/src/components/TubeMap.test.js
+++ b/src/components/TubeMap.test.js
@@ -30,7 +30,8 @@ let ex6 = {
     ex6nodes,
     ex6tracks,
     readsFromStringToArray(exampleData.demoReads)
-  ) 
+  ),
+  region: []
 }
 
 describe('TubeMap test', () => {

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -31,7 +31,12 @@ class TubeMapContainer extends Component {
   componentDidMount() {
     this.fetchCanceler = new AbortController();
     this.cancelSignal = this.fetchCanceler.signal;
-    this.getRemoteTubeMapData();
+    // this.getRemoteTubeMapData();
+    if( this.props.dataOrigin === dataOriginTypes.API) {
+      this.getRemoteTubeMapData()
+    } else {
+      this.getExampleData();
+    }
   }
 
   componentWillUnmount() {

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -7,12 +7,26 @@ import TubeMap from "./TubeMap";
 import * as tubeMap from "../util/tubemap";
 import { dataOriginTypes } from "../enums";
 import { fetchAndParse } from "../fetchAndParse";
+import TrackInfoPopper from "./TrackInfoPopper";
 
 class TubeMapContainer extends Component {
   state = {
     isLoading: true,
     error: null,
   };
+
+  onTrackClick = (title, trackID, elm) => {
+    this.setState({
+      trackInfo: title,
+      trackDialogOpen: true,
+      trackDialogTitle: title,
+      trackElm: elm
+    });
+  }
+
+  handleCloseTrackInfo = () => {
+    this.setState({trackDialogOpen: false, trackElm: null});
+  }
 
   componentDidMount() {
     this.fetchCanceler = new AbortController();
@@ -119,8 +133,14 @@ class TubeMapContainer extends Component {
             tracks={this.state.tracks}
             reads={this.state.reads}
             region={this.state.region}
+            onTrackClick={this.onTrackClick}
           />
         </div>
+       <TrackInfoPopper
+          content={this.state.trackInfo} 
+          anchorEl={this.state.trackElm}
+          handleClose={()=>this.setState({trackElm: null})}
+        />
       </div>
     );
   }

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -31,10 +31,12 @@ class TubeMapContainer extends Component {
   componentDidMount() {
     this.fetchCanceler = new AbortController();
     this.cancelSignal = this.fetchCanceler.signal;
-    // this.getRemoteTubeMapData();
+
     if( this.props.dataOrigin === dataOriginTypes.API) {
+      // The default will be API
       this.getRemoteTubeMapData()
     } else {
+      // But for testing we may choose an EXAMPLE data
       this.getExampleData();
     }
   }

--- a/src/components/TubeMapContainer.test.js
+++ b/src/components/TubeMapContainer.test.js
@@ -1,0 +1,94 @@
+import React from "react";
+import { screen, render, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import TubeMapContainer from "./TubeMapContainer";
+
+import config from "../config.json";
+import { dataOriginTypes } from "../enums";
+
+import * as fetchAndParseModule from "../fetchAndParse";
+
+
+// Tests functionality without server
+jest.mock("../fetchAndParse");
+
+let apiUrl, dataOrigin, viewTarget, visOptions;
+
+apiUrl = "";
+viewTarget = {};
+dataOrigin = dataOriginTypes.EXAMPLE_6;
+
+// default visOptions
+visOptions = {
+  removeRedundantNodes: true,
+  compressedView: false,
+  transparentNodes: false,
+  showReads: true,
+  showSoftClips: true,
+  colorReadsByMappingQuality: false,
+  colorSchemes: [
+            {...config.defaultHaplotypeColorPalette},
+            {...config.defaultHaplotypeColorPalette},
+            {...config.defaultReadColorPalette},
+            {...config.defaultReadColorPalette}],
+  mappingQualityCutoff: 0,
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  render(
+    <div>
+      <TubeMapContainer
+        viewTarget={viewTarget}
+        dataOrigin={dataOrigin}
+        apiUrl={apiUrl}
+        visOptions={visOptions}
+      />
+      <div id="legendDiv" data-testid="legendDiv"></div>
+    </div>
+  );
+});
+
+describe("TubeMapContainer", () => {
+  test("TubeMapContainer loads a tubemap", () => {
+        // All the tracks are loaded and rendered in the SVG.
+        expect(document.querySelector("[trackID='0']")).not.toBeNull();
+        expect(document.querySelector("[trackID='1']")).not.toBeNull();
+        expect(document.querySelector("[trackID='2']")).not.toBeNull();
+        expect(document.querySelector("[trackID='3']")).not.toBeNull();
+        expect(document.querySelector("[trackID='4']")).not.toBeNull();
+  });
+  test("Clicking a track will create a popup with the title", async () => {
+    // All the tracks are loaded and rendered in the SVG.
+    // Click Track 0
+    let track0 = document.querySelector("[trackID='0']");
+    await fireEvent.click(track0);
+
+    let title = track0.querySelector("title");
+    let titleText = title.textContent;
+
+    // Use ID rather than ByRole since role of tooltip might be confused with another tooltip
+    // This popper is specifically for allowing copy/paste while other tooltips may just activate on mouseover
+    let popperElm = document.querySelector("#track-info-popper");
+    expect(popperElm.textContent).toBe(titleText);
+  });
+
+  test("Click away will make popup disappear", async () => {
+    let track0 = document.querySelector("[trackID='0']");
+    await fireEvent.click(track0);
+    let title = track0.querySelector("title");
+    let titleText = title.textContent;
+
+    let popperElm = document.getElementById("track-info-popper");
+    expect(popperElm.textContent).toBe(titleText);
+
+    // click away from popper
+    let svgElm = screen.getByTestId("legendDiv");
+    await fireEvent.click(svgElm);
+
+    // the popper won't be found anymore
+    waitFor(() => expect(document.getElementById("track-info-popper")).toBe(null));
+  });
+
+});

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -3240,6 +3240,7 @@ function filterObjectByAttribute(attribute, value) {
   return (item) => item[attribute] === value;
 }
 
+// Keep event handlers which call callbacks here.
 const eventHandlerBase = {
   trackClick: function() {
     const trackID = d3.select(this).attr("trackID"); 
@@ -3251,12 +3252,14 @@ const eventHandlerBase = {
   }
 }
 
+// Keep event handlers that are set with setEventHandler from above here.
 const eventHandlers = {
-  trackClick: (title, trackID) => {if(DEBUG) console.log(`Track ${trackID} clicked (${title}).`);}
+  trackClick: (title, trackID, target) => {if(DEBUG) console.log(`Track ${trackID} clicked (${title}).`);}
 }
 
-// eventName must be one of: ["trackClick"]
-// callback function must accept the arguments: title, trackID
+// eventName must be "trackClick". 
+// callback function must accept the arguments: title, trackID, targetElm
+// The ability to handle more events could be added later in a similar fashion.
 export function setEventHandler(eventName, eventHandler) {
   eventHandlers[eventName] = eventHandler;
 }

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1119,7 +1119,7 @@ function alignSVG() {
       "height",
       (maxYCoordinate - minYCoordinate + 50) * d3.event.transform.k
     );
-    // adjust width to compensate for verical scroll bar appearing
+    // adjust width to compensate for vertical scroll bar appearing
     svg2.attr("width", document.getElementById("tubeMapSVG").clientWidth);
   }
 

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -3240,6 +3240,27 @@ function filterObjectByAttribute(attribute, value) {
   return (item) => item[attribute] === value;
 }
 
+const eventHandlerBase = {
+  trackClick: function() {
+    const trackID = d3.select(this).attr("trackID"); 
+    const titleElm = this.querySelector("title");
+    const title = titleElm ? titleElm.textContent : "";
+    if(eventHandlers.trackClick){
+      eventHandlers.trackClick(title, trackID, this);
+    }
+  }
+}
+
+const eventHandlers = {
+  trackClick: (title, trackID) => {if(DEBUG) console.log(`Track ${trackID} clicked (${title}).`);}
+}
+
+// eventName must be one of: ["trackClick"]
+// callback function must accept the arguments: title, trackID
+export function setEventHandler(eventName, eventHandler) {
+  eventHandlers[eventName] = eventHandler;
+}
+
 function drawTrackRectangles(rectangles, type) {
   if (typeof type === "undefined") type = "haplo";
   rectangles = rectangles.filter(filterObjectByAttribute("type", type));
@@ -3260,6 +3281,7 @@ function drawTrackRectangles(rectangles, type) {
     .on("mouseover", trackMouseOver)
     .on("mouseout", trackMouseOut)
     .on("dblclick", trackDoubleClick)
+    .on("click", eventHandlerBase.trackClick)
     .append("svg:title")
     .text((d) => getPopUpTrackText(d.name));
 }
@@ -3491,6 +3513,7 @@ function drawTrackCurves(type) {
     .on("mouseover", trackMouseOver)
     .on("mouseout", trackMouseOut)
     .on("dblclick", trackDoubleClick)
+    .on("click", eventHandlerBase.trackClick)
     .append("svg:title")
     .text((d) => getPopUpTrackText(d.name));
 }
@@ -3512,6 +3535,7 @@ function drawTrackCorners(corners, type) {
     .on("mouseover", trackMouseOver)
     .on("mouseout", trackMouseOut)
     .on("dblclick", trackDoubleClick)
+    .on("click", eventHandlerBase.trackClick)
     .append("svg:title")
     .text((d) => getPopUpTrackText(d.name));
 }

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -3240,30 +3240,6 @@ function filterObjectByAttribute(attribute, value) {
   return (item) => item[attribute] === value;
 }
 
-// Keep event handlers which call callbacks here.
-const eventHandlerBase = {
-  trackClick: function() {
-    const trackID = d3.select(this).attr("trackID"); 
-    const titleElm = this.querySelector("title");
-    const title = titleElm ? titleElm.textContent : "";
-    if(eventHandlers.trackClick){
-      eventHandlers.trackClick(title, trackID, this);
-    }
-  }
-}
-
-// Keep event handlers that are set with setEventHandler from above here.
-const eventHandlers = {
-  trackClick: (title, trackID, target) => {if(DEBUG) console.log(`Track ${trackID} clicked (${title}).`);}
-}
-
-// eventName must be "trackClick". 
-// callback function must accept the arguments: title, trackID, targetElm
-// The ability to handle more events could be added later in a similar fashion.
-export function setEventHandler(eventName, eventHandler) {
-  eventHandlers[eventName] = eventHandler;
-}
-
 function drawTrackRectangles(rectangles, type) {
   if (typeof type === "undefined") type = "haplo";
   rectangles = rectangles.filter(filterObjectByAttribute("type", type));
@@ -4340,4 +4316,33 @@ function filterReads(reads) {
     (read) =>
       !read.is_secondary && read.mapping_quality >= config.mappingQualityCutoff
   );
+}
+
+// This function allows you to set an event handler for "trackClick"
+// - eventName must be "trackClick". 
+// - callback function must accept the arguments: title, trackID, targetElm
+// The ability to handle more events could be added later in a similar fashion.
+export function setEventHandler(eventName, eventHandler) {
+  eventHandlers[eventName] = eventHandler;
+}
+
+// Event handlers that are set programmatically with setEventHandler are stored here.
+const eventHandlers = {
+  trackClick: (title, trackID, target) => {if(DEBUG) console.log(`Track ${trackID} clicked (${title}).`);}
+}
+
+// Keep event handlers which call the callbacks here.
+// These functions will be called directly by the eventListeners attached to the SVG,
+// so they must be function style, not arrow style => to have access to `this`.
+// To add more, be sure to add them to all the places in the code which create 
+// the elements you need to listen on.
+const eventHandlerBase = {
+  trackClick: function() {
+    const trackID = d3.select(this).attr("trackID"); 
+    const titleElm = this.querySelector("title");
+    const title = titleElm ? titleElm.textContent : "";
+    if(eventHandlers.trackClick){
+      eventHandlers.trackClick(title, trackID, this);
+    }
+  }
 }


### PR DESCRIPTION


Currently, the `title` of a read is displayed as a tooltip, but does not allow copy/paste. This PR adds an [MUI popper](https://mui.com/material-ui/react-popper/) that supports copy/paste. The popper is activated when a track on the SVG is clicked, and shows the contents of the `title` child of the element clicked. It is deactivated when there is a click-away event.

In the non-react `tubemap.js`, a callback for click is added in the places where `tubemap` draws the reads in the SVG. Also added in `tubemap.js` is a `setEventHandler` function for setting an arbitrary callback to be called on `trackClick`. This callback is stored in a hash in `tubemap.js`.

The popper is implemented in React on TubeMapContainer, which handles the state of the popper and creates the callback to pass to TubeMap. On TubeMap (in React), a prop is added to accept the callback.

The popper could be changed to a dialog, but it seems a popper is convenient since the tooltip string is quite short.